### PR TITLE
[FEAT][UHYU-99] 유저 방문 및 관심 브랜드 erd 수정 반영

### DIFF
--- a/app/user_recommendation.py
+++ b/app/user_recommendation.py
@@ -1,7 +1,5 @@
 import os
 import pandas as pd
-# 추천 결과와 클릭 행동 간의 카테고리 분포를 시각화하는 코드입니다.
-# 필요 라이브러리인 matplotlib과 seaborn을 import합니다.
 import matplotlib.pyplot as plt
 from sqlalchemy import create_engine, text
 from lightfm import LightFM
@@ -95,8 +93,7 @@ user_feature_map = defaultdict(list)
 
 for user_id, group in user_brand_df.groupby("user_id"):
     recent = group[group["data_type"] == "RECENT"]["brand_id"].tolist()[:6]
-    interest = group[group["data_type"] == "INTEREST"]["brand_id"].tolist()[:5]
-
+    interest = group[group["data_type"] == "INTEREST"]["brand_id"].tolist()[:3]
 
     # 관심 브랜드는 3개 있음 -> RECENT 데이터와의 편차를 줄이기 위해 가중치 조절로 균형잡힌 추천 제공
     features = (
@@ -291,9 +288,6 @@ def show_user_click_vs_recommendation(user_id, interaction_df, recommend_df, bra
 
     print("\n📍 방문 브랜드 (RECENT):")
     print(", ".join(recent_brands_names) if recent_brands_names else "없음")
-
-# 예시: 사용자 ID 2번에 대해 시각화
-# plot_user_category_distribution(user_id=2, interaction_df=interaction_df, recommend_df=recommend_df, brand_df=brand_df)
 
 for i in range(1,10) :
     print(f"user : {i}")


### PR DESCRIPTION
## 📌 작업 개요
- 기존에는 온보딩 시 입력받은 방문 브랜드(recentBrands)와 관심 브랜드(interestedBrands) 모두 RecommendationBaseData 테이블에 저장했으나, 구조적 혼동을 줄이기 위해 방문 브랜드는 History 테이블에 저장되도록 변경된 구조에 맞춰 코드를 수정
- 최근 방문 브랜드 정보 (history Table)은 앱 사용에 따라 무한히 늘어날 수 있는 데이터인 반면, 관심 브랜드 정보 (recommendation_base_data Table) 는 온보딩에서 명시적으로 1~3개 선택하거나 마이페이지에서 수정가능한 정보이다.
- 그대로 전부 사용하면 방문 브랜드의 정보가 관심 브랜드보다 과도하게 반영되어 추천이 왜곡될 수 있기 때문에 방문 브랜드는 6개, 관심 브랜드는 3개(코드상으로는 5개)까지만 불러와 추천에 반영하고, 갯수 차이로 인한 편차를 줄이기 위해 가중치 조절로 균형잡힌 추천 제공(방문 : 관심 = 2 : 3)

## ✨ 기타 참고 사항
- 추천 결과 저장 DB에서 category_id 속성이 제거되었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 추천 시스템에서 사용자의 관심 브랜드와 최근 방문 브랜드를 통합하여 더 다양한 브랜드 기반 추천이 제공됩니다.
  * 사용자별 관심 브랜드 고려 개수가 4개에서 3개로 조정되었습니다.
  * 관심 브랜드와 최근 방문 브랜드의 가중치 부여 방식이 변경되어 추천 정확도가 향상되었습니다.
  * 추천 결과에 카테고리 정보가 더 이상 포함되지 않습니다.
  * 일부 사용자 추천 결과 요약 표시 범위가 축소되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->