### PR TITLE
[FEATURE][UHYU-340] 단일 유저에 대해 재추천 및 

### DIFF
--- a/app/api/endpoint.py
+++ b/app/api/endpoint.py
@@ -2,7 +2,13 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 from app.model.recommender import generate_recommendation_for_user
 from app.config.database import get_engine
-from app.data.loader import load_user_data, load_brand_data, load_user_brand_data, load_interaction_data, load_bookmark_data
+from app.data.loader import (
+    load_user_data,
+    load_brand_data,
+    load_user_brand_data,
+    load_interaction_data,
+    load_bookmark_data,
+)
 from app.features.builder import build_user_features
 from app.model.trainer import prepare_dataset, build_interactions, train_model
 from app.saver.db_saver import save_to_db

--- a/app/data/loader.py
+++ b/app/data/loader.py
@@ -19,15 +19,20 @@ def load_brand_data(conn):
 
 def load_user_brand_data(conn, user_ids=None):
     base_query = """
-        SELECT user_id, brand_id, data_type FROM (
-            SELECT user_id, brand_id, 'INTEREST' as data_type FROM recommendation_base_data
+        SELECT combined.user_id, combined.brand_id, combined.data_type FROM (
+            SELECT user_id, brand_id, 'INTEREST' as data_type 
+            FROM recommendation_base_data WHERE data_type = 'INTEREST'
             UNION
-            SELECT DISTINCT user_id, brand_id, 'RECENT' as data_type FROM history WHERE visited_at IS NOT NULL
+            SELECT DISTINCT user_id, brand_id, 'RECENT' as data_type 
+            FROM history WHERE visited_at IS NOT NULL
         ) AS combined
+        LEFT JOIN recommendation_base_data rbd 
+          ON combined.user_id = rbd.user_id AND combined.brand_id = rbd.brand_id AND rbd.data_type = 'EXCLUDE'
+        WHERE rbd.id IS NULL
     """
     if user_ids is not None and len(user_ids) > 0:
         placeholder = ','.join([f':id{i}' for i in range(len(user_ids))])
-        base_query += f" WHERE user_id IN ({placeholder})"
+        base_query += f" AND user_id IN ({placeholder})"
         params = {f'id{i}': uid for i, uid in enumerate(user_ids)}
         result = conn.execute(text(base_query), params)
     else:
@@ -40,7 +45,10 @@ def load_interaction_data(conn, user_ids=None):
         FROM action_logs al
         JOIN store s ON al.store_id = s.id
         JOIN brands b ON s.brand_id = b.id
+        LEFT JOIN recommendation_base_data rbd 
+          ON al.user_id = rbd.user_id AND b.id = rbd.brand_id AND rbd.data_type = 'EXCLUDE'
         WHERE al.action_type IN ('MARKER_CLICK', 'FILTER_USED')
+          AND rbd.id IS NULL
     """
     if user_ids is not None and len(user_ids) > 0:
         placeholder = ','.join([f':id{i}' for i in range(len(user_ids))])
@@ -61,10 +69,28 @@ def load_bookmark_data(conn, user_ids=None):
         FROM bookmark b
         JOIN bookmark_list bl ON b.bookmark_list_id = bl.id
         JOIN store s ON b.store_id = s.id
+        LEFT JOIN recommendation_base_data rbd 
+          ON bl.user_id = rbd.user_id AND s.brand_id = rbd.brand_id AND rbd.data_type = 'EXCLUDE'
+        WHERE rbd.id IS NULL
     """
     if user_ids is not None and len(user_ids) > 0:
         placeholder = ','.join([f':id{i}' for i in range(len(user_ids))])
-        base_query += f" WHERE bl.user_id IN ({placeholder})"
+        base_query += f" AND bl.user_id IN ({placeholder})"
+        params = {f'id{i}': uid for i, uid in enumerate(user_ids)}
+        result = conn.execute(text(base_query), params)
+    else:
+        result = conn.execute(text(base_query))
+
+    return pd.DataFrame(result.fetchall(), columns=["user_id", "brand_id"])
+def load_exclude_brands(conn, user_ids=None):
+    base_query = """
+        SELECT user_id, brand_id
+        FROM recommendation_base_data
+        WHERE data_type = 'EXCLUDE'
+    """
+    if user_ids is not None and len(user_ids) > 0:
+        placeholder = ','.join([f':id{i}' for i in range(len(user_ids))])
+        base_query += f" AND user_id IN ({placeholder})"
         params = {f'id{i}': uid for i, uid in enumerate(user_ids)}
         result = conn.execute(text(base_query), params)
     else:

--- a/app/data/loader.py
+++ b/app/data/loader.py
@@ -32,7 +32,7 @@ def load_user_brand_data(conn, user_ids=None):
     """
     if user_ids is not None and len(user_ids) > 0:
         placeholder = ','.join([f':id{i}' for i in range(len(user_ids))])
-        base_query += f" AND user_id IN ({placeholder})"
+        base_query += f" AND combined.user_id IN ({placeholder})"
         params = {f'id{i}': uid for i, uid in enumerate(user_ids)}
         result = conn.execute(text(base_query), params)
     else:

--- a/app/features/builder.py
+++ b/app/features/builder.py
@@ -1,14 +1,16 @@
 from collections import defaultdict
 
-def build_user_features(user_brand_df, bookmark_df, brand_df):
+def build_user_features(user_brand_df, bookmark_df, brand_df, exclude_brand_ids=None):
+    exclude_brand_ids = set(exclude_brand_ids or [])
+
     user_feature_map = defaultdict(list)
     bookmark_map = bookmark_df.groupby("user_id")["brand_id"].apply(list).to_dict()
     brand_to_category = dict(zip(brand_df["brand_id"], brand_df["category_id"]))
 
     for user_id, group in user_brand_df.groupby("user_id"):
-        recent = group[group["data_type"] == "RECENT"]["brand_id"].tolist()[:6]
-        interest = group[group["data_type"] == "INTEREST"]["brand_id"].tolist()[:3]
-        bookmarked = bookmark_map.get(user_id, [])[:5]
+        recent = group[(group["data_type"] == "RECENT") & (~group["brand_id"].isin(exclude_brand_ids))]["brand_id"].tolist()[:6]
+        interest = group[(group["data_type"] == "INTEREST") & (~group["brand_id"].isin(exclude_brand_ids))]["brand_id"].tolist()[:3]
+        bookmarked = [b for b in bookmark_map.get(user_id, []) if b not in exclude_brand_ids][:5]
 
         features = (
             [f"recent_{b}" for b in recent] * 2 +

--- a/app/main.py
+++ b/app/main.py
@@ -33,9 +33,14 @@ def main():
         bookmark_df = load_bookmark_data(conn)
         print(f"⭐ 즐겨찾기 수: {len(bookmark_df)}")
 
+        print("📥 EXCLUDE 브랜드 로딩 중...")
+        exclude_brand_df = load_exclude_brands(conn)
+        exclude_brand_ids = set(exclude_brand_df["brand_id"].tolist())
+        print(f"🚫 제외 브랜드 수: {len(exclude_brand_ids)}")
+
     # 피처 생성
     print("🛠️ 사용자 피처 생성 중...")
-    user_feature_map = build_user_features(user_brand_df, bookmark_df, brand_df)
+    user_feature_map = build_user_features(user_brand_df, bookmark_df, brand_df, exclude_brand_ids=exclude_brand_ids)
 
     print("📦 데이터셋 구성 중...")
     dataset = prepare_dataset(user_df, brand_df, user_feature_map)
@@ -52,7 +57,7 @@ def main():
 
     # 추천 생성
     print("📊 추천 결과 생성 중...")
-    recommend_df = generate_recommendations(user_df, brand_df, model, dataset, user_features)
+    recommend_df = generate_recommendations(user_df, brand_df, model, dataset, user_features, exclude_brand_ids=exclude_brand_ids)
     print(f"🎯 추천 결과 개수: {len(recommend_df)}")
 
     # DB 저장

--- a/app/model/recommender.py
+++ b/app/model/recommender.py
@@ -25,10 +25,14 @@ def _build_recommendation_result(user_id, scores, item_indices, index_to_brand_i
         for rank, idx in enumerate(top_k_indices, start=1)
     ]
 
-def generate_recommendations(user_df, brand_df, model, dataset, user_features, top_k=5):
+def generate_recommendations(user_df, brand_df, model, dataset, user_features, top_k=5, exclude_brand_ids=None):
     _, _, item_mapping, _ = dataset.mapping()
     index_to_brand_id = {v: k for k, v in item_mapping.items()}
-    item_indices = list(index_to_brand_id.keys())
+
+    if exclude_brand_ids:
+        item_indices = [idx for idx in index_to_brand_id if index_to_brand_id[idx] not in exclude_brand_ids]
+    else:
+        item_indices = list(index_to_brand_id.keys())
 
     results = []
     for user_id in user_df["user_id"]:
@@ -38,10 +42,14 @@ def generate_recommendations(user_df, brand_df, model, dataset, user_features, t
 
     return pd.DataFrame(results)
 
-def generate_recommendation_for_user(user_id, user_df, brand_df, model, dataset, user_features, top_k=5):
+def generate_recommendation_for_user(user_id, user_df, brand_df, model, dataset, user_features, top_k=5, exclude_brand_ids=None):
     _, _, item_mapping, _ = dataset.mapping()
     index_to_brand_id = {v: k for k, v in item_mapping.items()}
-    item_indices = list(index_to_brand_id.keys())
+
+    if exclude_brand_ids:
+        item_indices = [idx for idx in index_to_brand_id if index_to_brand_id[idx] not in exclude_brand_ids]
+    else:
+        item_indices = list(index_to_brand_id.keys())
 
     if user_id not in user_df["user_id"].values:
         return pd.DataFrame([])


### PR DESCRIPTION
- api 요청에 대해 기존에는 프론트에서 요청하는 것을 고려하여 토큰에서 유저 id 를 추출하도록 했는데 spring 서버에서 요청하는 로직으로 변경함에 따라 post 요청 및 body에 user_id를 담아 보내도록 수정
- 요청 api url 수정
- recommendation_base_data 에 dataType이 exclude 인 데이터를 제외하고 추천 로직 재실행 : 단일 / 전체 추천에 모두 반영