### PR TITLE
[FEAT][UHYU-393] 추천 결과 저장 시 통계 테이블(statistics)에 함께 저장되도록 기능 추가

### DIFF
--- a/app/api/endpoint.py
+++ b/app/api/endpoint.py
@@ -74,7 +74,7 @@ def recommend_on_demand(request_body: UserRequest):
             raise HTTPException(status_code=404, detail="추천할 브랜드가 없습니다.")
 
         # 6. DB 저장
-        save_to_db(engine, recommend_df)
+        save_to_db(engine, recommend_df, brand_df, category_df)
 
         # 7. 응답 반환
         return {

--- a/app/data/loader.py
+++ b/app/data/loader.py
@@ -16,10 +16,23 @@ def load_user_data(conn, user_ids=None):
 
     return pd.DataFrame(result.fetchall(), columns=["user_id", "gender", "age_range"])
 
+# def load_brand_data(conn):
+#     return pd.DataFrame(conn.execute(text(
+#         "SELECT id, brand_name, category_id FROM brands"
+#     )).fetchall(), columns=["brand_id", "brand_name", "category_id"])
+
 def load_brand_data(conn):
     return pd.DataFrame(conn.execute(text(
-        "SELECT id, brand_name, category_id FROM brands"
-    )).fetchall(), columns=["brand_id", "brand_name", "category_id"])
+        """
+        SELECT 
+            b.id AS brand_id,
+            b.brand_name,
+            b.category_id,
+            c.category_name AS category_name
+        FROM brands b
+        JOIN categories c ON b.category_id = c.id
+        """
+    )).fetchall(), columns=["brand_id", "brand_name", "category_id", "category_name"])
 
 def load_user_brand_data(conn, user_ids=None):
     base_query = """

--- a/app/main.py
+++ b/app/main.py
@@ -69,9 +69,17 @@ def main():
     )
     print(f"🎯 추천 결과 개수: {len(recommend_df)}")
 
+    # statistics에 저장하기 위한 데이터 생성
+    brand_df = pd.read_sql(
+        "SELECT id as brand_id, brand_name, category_id FROM brand", engine
+    )
+    category_df = pd.read_sql(
+        "SELECT id as category_id, name as category_name FROM category", engine
+    )
+
     # DB 저장
     print("💾 추천 결과 DB 저장 중...")
-    save_to_db(engine, recommend_df)
+    save_to_db(engine, recommend_df, brand_df, category_df)
 
     # CSV 저장
     # print("📄 추천 결과 CSV 저장 중...")

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ from app.features.builder import build_user_features, build_item_features
 from app.model.trainer import prepare_dataset, build_interactions, train_model
 from app.model.recommender import generate_recommendations
 from app.saver.db_saver import save_to_db
+from app.utils.statistics import prepare_statistics_df
 from app.saver.file_exporter import save_to_csv
 
 def main():
@@ -80,25 +81,7 @@ def main():
     # save_to_csv(recommend_df)
 
     # 📊 통계용 데이터 구성
-    print("📊 통계 데이터 구성 중...")
-    statistics_df = recommend_df.merge(
-        brand_df[['brand_id', 'brand_name', 'category_id', 'category_name']],
-        on='brand_id',
-        how='left'
-    )
-
-    statistics_df = statistics_df[[
-        'user_id', 'brand_id', 'brand_name', 'category_id', 'category_name'
-    ]].copy()
-
-    statistics_df['my_map_list_id'] = None
-    statistics_df['store_id'] = None
-    statistics_df['statistics_type'] = 'RECOMMENDATION'
-    statistics_df['created_at'] = datetime.now()
-    statistics_df['updated_at'] = datetime.now()
-
-    # 누락된 브랜드 정보 제거
-    statistics_df = statistics_df.dropna(subset=['brand_name', 'category_id', 'category_name'])
+    statistics_df = prepare_statistics_df(recommend_df, brand_df)
 
     # DB에 통계 저장
     try:

--- a/app/saver/db_saver.py
+++ b/app/saver/db_saver.py
@@ -1,14 +1,6 @@
 from sqlalchemy import text
 
-def save_to_db(engine, recommend_df, brand_df, category_df):
-
-    # 1. brand 정보 merge
-    df = recommend_df.merge(brand_df, left_on="brand_id", right_on="brand_id", how="left")
-
-    # 2. category 정보 merge
-    df = df.merge(category_df, left_on="category_id", right_on="category_id", how="left")
-
-    # 3. recommendation 저장
+def save_to_db(engine, recommend_df):
     with engine.begin() as conn:
         conn.execute(
             text("""
@@ -18,25 +10,44 @@ def save_to_db(engine, recommend_df, brand_df, category_df):
             recommend_df[["user_id", "brand_id", "score", "rank", "created_at", "updated_at"]].to_dict("records")
         )
 
-        # 4. statistics 저장
+def save_statistics(engine, statistics_df):
+    if statistics_df.empty:
+        print("⚠️ 저장할 통계 데이터가 없습니다.")
+        return
+
+    statistics_records = []
+    for row in statistics_df.itertuples(index=False):
+        if not all([row.brand_name, row.category_id, row.category_name]):
+            continue  # 누락된 정보가 있다면 저장하지 않음
+
+        statistics_records.append({
+            "user_id": row.user_id,
+            "my_map_list_id": None,
+            "store_id": None,
+            "brand_id": row.brand_id,
+            "brand_name": row.brand_name,
+            "category_id": row.category_id,
+            "category_name": row.category_name,
+            "statistics_type": "RECOMMENDATION",
+            "created_at": row.created_at,
+            "updated_at": row.updated_at,
+        })
+
+    with engine.begin() as conn:
         conn.execute(
             text("""
                 INSERT INTO statistics (
-                    user_id, brand_id, brand_name,
-                    category_id, category_name,
+                    user_id, my_map_list_id, store_id,
+                    brand_id, brand_name, category_id, category_name,
                     statistics_type, created_at, updated_at
                 )
                 VALUES (
-                    :user_id, :brand_id, :brand_name,
-                    :category_id, :category_name,
+                    :user_id, :my_map_list_id, :store_id,
+                    :brand_id, :brand_name, :category_id, :category_name,
                     :statistics_type, :created_at, :updated_at
                 )
             """),
-            df.assign(
-                statistics_type="RECOMMENDATION"
-            )[[
-                "user_id", "brand_id", "brand_name",
-                "category_id", "category_name",
-                "statistics_type", "created_at", "updated_at"
-            ]].to_dict("records")
+            statistics_records
         )
+
+    print(f"📊 통계 {len(statistics_records)}건 저장 완료")

--- a/app/saver/db_saver.py
+++ b/app/saver/db_saver.py
@@ -1,4 +1,6 @@
 from sqlalchemy import text
+import logging
+logger = logging.getLogger(__name__)
 
 def save_to_db(engine, recommend_df):
     with engine.begin() as conn:
@@ -12,26 +14,28 @@ def save_to_db(engine, recommend_df):
 
 def save_statistics(engine, statistics_df):
     if statistics_df.empty:
-        print("⚠️ 저장할 통계 데이터가 없습니다.")
+        logger.warning("⚠️ 저장할 통계 데이터가 없습니다.")
         return
 
-    statistics_records = []
-    for row in statistics_df.itertuples(index=False):
-        if not all([row.brand_name, row.category_id, row.category_name]):
-            continue  # 누락된 정보가 있다면 저장하지 않음
+    # statistics_records = []
+    # for row in statistics_df.itertuples(index=False):
+    #     if not all([row.brand_name, row.category_id, row.category_name]):
+    #         continue  # 누락된 정보가 있다면 저장하지 않음
+    #
+    #     statistics_records.append({
+    #         "user_id": row.user_id,
+    #         "my_map_list_id": None,
+    #         "store_id": None,
+    #         "brand_id": row.brand_id,
+    #         "brand_name": row.brand_name,
+    #         "category_id": row.category_id,
+    #         "category_name": row.category_name,
+    #         "statistics_type": "RECOMMENDATION",
+    #         "created_at": row.created_at,
+    #         "updated_at": row.updated_at,
+    #     })
 
-        statistics_records.append({
-            "user_id": row.user_id,
-            "my_map_list_id": None,
-            "store_id": None,
-            "brand_id": row.brand_id,
-            "brand_name": row.brand_name,
-            "category_id": row.category_id,
-            "category_name": row.category_name,
-            "statistics_type": "RECOMMENDATION",
-            "created_at": row.created_at,
-            "updated_at": row.updated_at,
-        })
+    statistics_records = statistics_df.to_dict('records')
 
     with engine.begin() as conn:
         conn.execute(
@@ -50,4 +54,4 @@ def save_statistics(engine, statistics_df):
             statistics_records
         )
 
-    print(f"📊 통계 {len(statistics_records)}건 저장 완료")
+    logger.info(f"📊 통계 {len(statistics_records)}건 저장 완료")

--- a/app/saver/db_saver.py
+++ b/app/saver/db_saver.py
@@ -16,25 +16,7 @@ def save_statistics(engine, statistics_df):
     if statistics_df.empty:
         logger.warning("⚠️ 저장할 통계 데이터가 없습니다.")
         return
-
-    # statistics_records = []
-    # for row in statistics_df.itertuples(index=False):
-    #     if not all([row.brand_name, row.category_id, row.category_name]):
-    #         continue  # 누락된 정보가 있다면 저장하지 않음
-    #
-    #     statistics_records.append({
-    #         "user_id": row.user_id,
-    #         "my_map_list_id": None,
-    #         "store_id": None,
-    #         "brand_id": row.brand_id,
-    #         "brand_name": row.brand_name,
-    #         "category_id": row.category_id,
-    #         "category_name": row.category_name,
-    #         "statistics_type": "RECOMMENDATION",
-    #         "created_at": row.created_at,
-    #         "updated_at": row.updated_at,
-    #     })
-
+    
     statistics_records = statistics_df.to_dict('records')
 
     with engine.begin() as conn:

--- a/app/saver/db_saver.py
+++ b/app/saver/db_saver.py
@@ -1,6 +1,14 @@
 from sqlalchemy import text
 
-def save_to_db(engine, recommend_df):
+def save_to_db(engine, recommend_df, brand_df, category_df):
+
+    # 1. brand 정보 merge
+    df = recommend_df.merge(brand_df, left_on="brand_id", right_on="brand_id", how="left")
+
+    # 2. category 정보 merge
+    df = df.merge(category_df, left_on="category_id", right_on="category_id", how="left")
+
+    # 3. recommendation 저장
     with engine.begin() as conn:
         conn.execute(
             text("""
@@ -8,4 +16,27 @@ def save_to_db(engine, recommend_df):
                 VALUES (:user_id, :brand_id, :score, :rank, :created_at, :updated_at)
             """),
             recommend_df[["user_id", "brand_id", "score", "rank", "created_at", "updated_at"]].to_dict("records")
+        )
+
+        # 4. statistics 저장
+        conn.execute(
+            text("""
+                INSERT INTO statistics (
+                    user_id, brand_id, brand_name,
+                    category_id, category_name,
+                    statistics_type, created_at, updated_at
+                )
+                VALUES (
+                    :user_id, :brand_id, :brand_name,
+                    :category_id, :category_name,
+                    :statistics_type, :created_at, :updated_at
+                )
+            """),
+            df.assign(
+                statistics_type="RECOMMENDATION"
+            )[[
+                "user_id", "brand_id", "brand_name",
+                "category_id", "category_name",
+                "statistics_type", "created_at", "updated_at"
+            ]].to_dict("records")
         )

--- a/app/utils/statistics.py
+++ b/app/utils/statistics.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+
+def prepare_statistics_df(recommend_df, brand_df):
+    print("📊 통계 데이터 구성 중...")
+    statistics_df = recommend_df.merge(
+        brand_df[['brand_id', 'brand_name', 'category_id', 'category_name']],
+        on='brand_id',
+        how='left'
+    )
+
+    statistics_df = statistics_df[[
+        'user_id', 'brand_id', 'brand_name', 'category_id', 'category_name'
+    ]].copy()
+
+    statistics_df['my_map_list_id'] = None
+    statistics_df['store_id'] = None
+    statistics_df['statistics_type'] = 'RECOMMENDATION'
+    statistics_df['created_at'] = datetime.now()
+    statistics_df['updated_at'] = datetime.now()
+
+    # 누락된 브랜드 정보 제거
+    return statistics_df.dropna(subset=['brand_name', 'category_id', 'category_name'])


### PR DESCRIPTION
## 📌 작업 개요
- 추천 결과를 저장할 때, 사용자별 추천 통계를 함께 statistics 테이블에 기록하도록 기능을 확장했습니다.
- main.py의 배치 추천 로직과 /re-recommendation API 요청 처리 로직에 공통적으로 적용하였습니다.
- 추천 결과(recommend_df)와 브랜드 정보(brand_df)를 merge하여 statistics_df를 구성하고, save_statistics()를 통해 DB에 저장되도록 처리했습니다.

✨ 기타 참고 사항
- load_brand_data() 함수에서 category_name을 포함하도록 SQL 쿼리를 변경하였습니다.
- statistics_type은 RECOMMENDATION으로 고정 저장됩니다.
- brand_name, category_id, category_name 중 하나라도 누락된 경우 해당 행은 저장되지 않도록 dropna() 처리 적용하였습니다.
- /re-recommendation API를 통해 재추천이 발생해도 통계가 누락되지 않고 저장되도록 설계했습니다.

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 추천 결과와 함께 브랜드 및 카테고리 정보를 포함한 통계 데이터가 저장됩니다.
  * 통계 데이터는 추천 내역에 대한 브랜드명, 카테고리명 등 추가 정보를 포함합니다.

* **버그 수정**
  * 누락된 브랜드 또는 카테고리 정보가 있는 데이터는 저장되지 않도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->